### PR TITLE
Fix: Enable cookies for cross-domain requests 

### DIFF
--- a/template.go
+++ b/template.go
@@ -155,6 +155,7 @@ var graphiqlTmpl = `
         // Change this to point wherever you host your GraphQL server.
         return fetch('{{ .Endpoint }}', {
             method: 'post',
+	    credentials: 'include',
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',


### PR DESCRIPTION
This will enable user to make authenticated requests to another domain (if Cross-Origin Resource Sharing policy of this domain allows user to do so). Authentication should be done before in a separate tab.